### PR TITLE
Pod name updates to user Nexmo-Stitch

### DIFF
--- a/docs/1-simple-conversation-objc.md
+++ b/docs/1-simple-conversation-objc.md
@@ -37,13 +37,12 @@ Navigate to the project's root directory in the Terminal. Run: `pod init`. Open 
 # Uncomment the next line to define a global platform for your project
 platform :ios, '10.0'
 
-source "https://github.com/Nexmo/PodSpec.git"
 source 'git@github.com:CocoaPods/Specs.git'
 
 target 'simple-conversation-objc' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-  pod "Nexmo-Stitch", :git => "https://github.com/nexmo/conversation-ios-sdk.git", :branch => "master" # development
+  pod "Nexmo-Stitch"
 end
 ```
 

--- a/docs/1-simple-conversation.md
+++ b/docs/1-simple-conversation.md
@@ -152,13 +152,11 @@ Navigate to the project's root directory in the Terminal. Run: `pod init`. Open 
 # Uncomment the next line to define a global platform for your project
 platform :ios, '9.0'
 
-source "https://github.com/Nexmo/PodSpec.git"
 source 'git@github.com:CocoaPods/Specs.git'
 
 target 'QuickStartOne' do
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
   use_frameworks!
-  pod "NexmoConversation", :git => "https://github.com/nexmo/conversation-ios-sdk.git", :branch => "master" # development
+  pod "Nexmo-Stitch"
 end
 
 ```
@@ -173,7 +171,7 @@ Let's layout the login functionality. Set constraints on the top & leading attri
 
 ### 2.5 - Create the Login Functionality
 
-Below `UIKit` let's import the `NexmoConversation`. Next we setup a custom instance of the `ConversationClient` and saving it as a member variable in the view controller. 
+Below `UIKit` let's import `Stitch` framework. Next we setup a custom instance of the `ConversationClient` and saving it as a member variable in the view controller. 
 
 ```Swift
     /// Nexmo Conversation client
@@ -308,7 +306,7 @@ Like last time we'll wire up the views in `ChatViewController.swift` We also nee
 ```Swift
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class ChatController: UIViewController {
     

--- a/docs/4-enable-audio.md
+++ b/docs/4-enable-audio.md
@@ -44,13 +44,12 @@ platform :ios, '10.0'
 
 use_frameworks!
 
-source "https://github.com/Nexmo/PodSpec.git"
 source 'git@github.com:CocoaPods/Specs.git'
 
 
 target 'enable-audio' do
 
-  pod "Nexmo-Stitch" #, :git => "https://github.com/nexmo/conversation-ios-sdk.git", :branch => "release" # development
+  pod "Nexmo-Stitch"
 
 end
 ```
@@ -65,7 +64,7 @@ Let's layout the login functionality. Set constraints on the top & leading attri
 
 ### 1.4 - Create the Login Functionality
 
-Below `UIKit` let's import the `NexmoConversation`. Next we setup a custom instance of the `ConversationClient` and saving it as a member variable in the view controller.
+Below `UIKit` let's import the `Stitch` framework. Next we setup a custom instance of the `ConversationClient` and saving it as a member variable in the view controller.
 
 ```swift
 /// Nexmo Conversation client
@@ -199,7 +198,7 @@ Like last time we'll wire up the views in `ChatViewController.swift` We also nee
 ```swift
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class ChatController: UIViewController {
 

--- a/examples/Podfile
+++ b/examples/Podfile
@@ -1,11 +1,11 @@
-platform :ios, '9.0'
+ platform :ios, '10.0'
 
 use_frameworks!
 
 source 'git@github.com:CocoaPods/Specs.git'
 
 def podsList
-    pod "Stitch"
+    pod "Nexmo-Stitch"
 end
 
 target 'QuickStartOne' do

--- a/examples/Podfile
+++ b/examples/Podfile
@@ -8,7 +8,7 @@ def podsList
     pod "Nexmo-Stitch"
 end
 
-target 'QuickStartOne' do
+target 'QuickStartsOne' do
     podsList
 end
 

--- a/examples/Podfile.lock
+++ b/examples/Podfile.lock
@@ -1,33 +1,40 @@
 PODS:
-  - Alamofire (4.6.0)
-  - NexmoGRDB.swift (0.90.3)
-  - NexmoWebRTC (63.11.16)
-  - RxCocoa (4.1.2):
+  - Alamofire (4.7.3)
+  - Nexmo-Stitch (1.8.0):
+    - Alamofire (~> 4.0)
+    - NexmoGRDB.swift (~> 0.90)
+    - NexmoWebRTC (~> 63.11)
     - RxSwift (~> 4.0)
-  - RxSwift (4.1.2)
-  - Socket.IO-Client-Swift (13.1.1):
+    - Socket.IO-Client-Swift (~> 13.0)
+  - NexmoGRDB.swift (0.90.5)
+  - NexmoWebRTC (63.11.16)
+  - RxSwift (4.2.0)
+  - Socket.IO-Client-Swift (13.3.0):
     - Starscream (~> 3.0.2)
-  - Starscream (3.0.4)
-  - Stitch (0.21.1):
-    - Alamofire (~> 4.6.0)
-    - NexmoGRDB.swift (~> 0.90.3)
-    - NexmoWebRTC (~> 63.11.16)
-    - RxCocoa (~> 4.1.2)
-    - Socket.IO-Client-Swift (~> 13.1.1)
+  - Starscream (3.0.5)
 
 DEPENDENCIES:
-  - Stitch
+  - Nexmo-Stitch
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Nexmo-Stitch
+    - NexmoGRDB.swift
+    - NexmoWebRTC
+    - RxSwift
+    - Socket.IO-Client-Swift
+    - Starscream
 
 SPEC CHECKSUMS:
-  Alamofire: f41a599bd63041760b26d393ec1069d9d7b917f4
-  NexmoGRDB.swift: 9d8f304ccfda140dd94c572299fd5b967713a1d0
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  Nexmo-Stitch: ecb45e5573ce0ada64c349e91850bccbffc7b7ed
+  NexmoGRDB.swift: a3f76f83f87c0836f3b2cdb375aa7e9e9f8bce3a
   NexmoWebRTC: 259075ae09616c4b847024f0dccd22650dc3a14c
-  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
-  RxSwift: e49536837d9901277638493ea537394d4b55f570
-  Socket.IO-Client-Swift: f22222913f29801e30ae0df712db663ec096edc2
-  Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
-  Stitch: dd9eb0e1c2bf06cc827ac77769db9572f83c7307
+  RxSwift: 99e10317ddfcc7fbe01356aafd118fde4a0be104
+  Socket.IO-Client-Swift: 0afb192a562db90d50e3f7f7421c06925a3f0179
+  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
 
-PODFILE CHECKSUM: 4e3baf1f724758c28fcb0375eb817472f0d76bef
+PODFILE CHECKSUM: 8e12904bf0a2dd4515821546e80f95fb7eda23ed
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2

--- a/examples/QuickStartOne/ChatController.swift
+++ b/examples/QuickStartOne/ChatController.swift
@@ -5,7 +5,7 @@
 
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class ChatController: UIViewController {
     

--- a/examples/QuickStartOne/LoginController.swift
+++ b/examples/QuickStartOne/LoginController.swift
@@ -5,7 +5,7 @@
 
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class LoginController: UIViewController {
 

--- a/examples/QuickStartOne/Podfile
+++ b/examples/QuickStartOne/Podfile
@@ -2,11 +2,10 @@ platform :ios, '9.0'
 
 use_frameworks!
 
-source "https://github.com/Nexmo/PodSpec.git"
 source 'git@github.com:CocoaPods/Specs.git'
 
 def nexmoConversationPod
-    pod "NexmoConversation", :git => "https://github.com/nexmo/conversation-ios-sdk.git", :branch => "release" # development
+    pod "Nexmo-Stitch"
 end
 
 target 'QuickStartOne' do

--- a/examples/QuickStartOne/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/QuickStartOne/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/examples/QuickStartOne/Supporting Files/Base.lproj/Main.storyboard
+++ b/examples/QuickStartOne/Supporting Files/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="gIM-Rr-E83">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="gIM-Rr-E83">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,7 +13,7 @@
         <!--Login Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController storyboardIdentifier="chatView" id="BYZ-38-t0r" customClass="LoginController" customModule="QuickStartOne" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="chatView" id="BYZ-38-t0r" customClass="LoginController" customModule="QuickStartsOne" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
@@ -67,7 +67,7 @@
                     </view>
                     <navigationItem key="navigationItem" id="0F0-68-USf"/>
                     <connections>
-                        <outlet property="statusLbl" destination="gOV-m2-ka6" id="uae-8b-cdy"/>
+                        <outlet property="statusLbl" destination="gOV-m2-ka6" id="ki0-OL-iGl"/>
                         <segue destination="rTc-eL-BAN" kind="show" identifier="chatView" id="rIq-Yi-x0c"/>
                     </connections>
                 </viewController>
@@ -78,7 +78,7 @@
         <!--Chat Controller-->
         <scene sceneID="Zyz-r4-L3T">
             <objects>
-                <viewController storyboardIdentifier="ChatController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="rTc-eL-BAN" customClass="ChatController" customModule="QuickStartOne" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="ChatController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="rTc-eL-BAN" customClass="ChatController" customModule="QuickStartsOne" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Lbn-6E-HQG"/>
                         <viewControllerLayoutGuide type="bottom" id="bdE-tq-CQ9"/>

--- a/examples/QuickStartThree/Podfile
+++ b/examples/QuickStartThree/Podfile
@@ -1,14 +1,13 @@
 # Uncomment the next line to define a global platform for your project
 # platform :ios, '9.0'
 
-use_frameworks!
 
 source 'https://github.com/CocoaPods/Specs.git'
 
 
 target 'QuickStartThree' do
-  # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
 
+  use_frameworks!
   # Pods for QuickStartThree
   pod 'Nexmo-Stitch'
 

--- a/examples/QuickStartThree/Podfile
+++ b/examples/QuickStartThree/Podfile
@@ -3,7 +3,6 @@
 
 use_frameworks!
 
-source 'https://github.com/Nexmo/stitch-ios-sdk.git'
 source 'https://github.com/CocoaPods/Specs.git'
 
 
@@ -11,6 +10,6 @@ target 'QuickStartThree' do
   # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
 
   # Pods for QuickStartThree
-  pod 'Stitch'
+  pod 'Nexmo-Stitch'
 
 end

--- a/examples/QuickStartThree/Podfile.lock
+++ b/examples/QuickStartThree/Podfile.lock
@@ -1,33 +1,40 @@
 PODS:
-  - Alamofire (4.6.0)
-  - NexmoGRDB.swift (0.90.3)
-  - NexmoWebRTC (63.11.16)
-  - RxCocoa (4.1.2):
+  - Alamofire (4.7.3)
+  - Nexmo-Stitch (1.8.0):
+    - Alamofire (~> 4.0)
+    - NexmoGRDB.swift (~> 0.90)
+    - NexmoWebRTC (~> 63.11)
     - RxSwift (~> 4.0)
-  - RxSwift (4.1.2)
-  - Socket.IO-Client-Swift (13.1.2):
+    - Socket.IO-Client-Swift (~> 13.0)
+  - NexmoGRDB.swift (0.90.5)
+  - NexmoWebRTC (63.11.16)
+  - RxSwift (4.2.0)
+  - Socket.IO-Client-Swift (13.3.0):
     - Starscream (~> 3.0.2)
-  - Starscream (3.0.4)
-  - Stitch (0.23.0):
-    - Alamofire (~> 4.6.0)
-    - NexmoGRDB.swift (~> 0.90.3)
-    - NexmoWebRTC (~> 63.11.16)
-    - RxCocoa (~> 4.1.2)
-    - Socket.IO-Client-Swift (~> 13.1.1)
+  - Starscream (3.0.5)
 
 DEPENDENCIES:
-  - Stitch
+  - Nexmo-Stitch
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Nexmo-Stitch
+    - NexmoGRDB.swift
+    - NexmoWebRTC
+    - RxSwift
+    - Socket.IO-Client-Swift
+    - Starscream
 
 SPEC CHECKSUMS:
-  Alamofire: f41a599bd63041760b26d393ec1069d9d7b917f4
-  NexmoGRDB.swift: 9d8f304ccfda140dd94c572299fd5b967713a1d0
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  Nexmo-Stitch: ecb45e5573ce0ada64c349e91850bccbffc7b7ed
+  NexmoGRDB.swift: a3f76f83f87c0836f3b2cdb375aa7e9e9f8bce3a
   NexmoWebRTC: 259075ae09616c4b847024f0dccd22650dc3a14c
-  RxCocoa: d88ba0f1f6abf040011a9eb4b539324fc426843a
-  RxSwift: e49536837d9901277638493ea537394d4b55f570
-  Socket.IO-Client-Swift: 010d2f464bdd1849b859c0cd0500d68194401ac8
-  Starscream: f5da93fe6984c77b694366bf7299b7dc63a76f26
-  Stitch: 98f11384dfd41ddda2c44eeeb8ae66347b758cef
+  RxSwift: 99e10317ddfcc7fbe01356aafd118fde4a0be104
+  Socket.IO-Client-Swift: 0afb192a562db90d50e3f7f7421c06925a3f0179
+  Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
 
-PODFILE CHECKSUM: 9ab81ad0d03fbc471f3222734a45090a5b9ad3d1
+PODFILE CHECKSUM: f9b6ed7d3fab79c3c9b1d7ed203476ce1b92dcd3
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2

--- a/examples/QuickStartThree/QuickStartThree.xcodeproj/project.pbxproj
+++ b/examples/QuickStartThree/QuickStartThree.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 				99509F802059B37600A3E995 /* Frameworks */,
 				99509F812059B37600A3E995 /* Resources */,
 				A1AD3224BF8CEFF10E1980E1 /* [CP] Embed Pods Frameworks */,
-				DB9675FF5AB3FD56C68A4421 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -170,26 +169,24 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartThree/Pods-QuickStartThree-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/NexmoGRDB.swift/GRDB.framework",
 				"${PODS_ROOT}/NexmoWebRTC/WebRTC.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/Socket.IO-Client-Swift/SocketIO.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework.dSYM",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Stitch.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Stitch.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GRDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SocketIO.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NexmoConversation.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/NexmoConversation.framework.dSYM",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -212,21 +209,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DB9675FF5AB3FD56C68A4421 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartThree/Pods-QuickStartThree-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/examples/QuickStartThree/QuickStartThree/ChatViewController.swift
+++ b/examples/QuickStartThree/QuickStartThree/ChatViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class ChatViewController: UIViewController {
     
@@ -156,11 +156,11 @@ class ChatViewController: UIViewController {
 extension ChatViewController : UITableViewDelegate {
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        <#code#>
+        
     }
     
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {
-        <#code#>
+        
     }
     
 }

--- a/examples/QuickStartThree/QuickStartThree/LoginViewController.swift
+++ b/examples/QuickStartThree/QuickStartThree/LoginViewController.swift
@@ -4,7 +4,7 @@
 //
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class LoginViewController: UIViewController {
     

--- a/examples/QuickStartTwo/ChatController.swift
+++ b/examples/QuickStartTwo/ChatController.swift
@@ -5,7 +5,7 @@
 
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class ChatController: UIViewController {
     

--- a/examples/QuickStartTwo/LoginController.swift
+++ b/examples/QuickStartTwo/LoginController.swift
@@ -5,7 +5,7 @@
 
 
 import UIKit
-import NexmoConversation
+import Stitch
 
 class LoginViewController: UIViewController {
     

--- a/examples/QuickStartTwo/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/QuickStartTwo/Supporting Files/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/examples/QuickStarts.xcodeproj/project.pbxproj
+++ b/examples/QuickStarts.xcodeproj/project.pbxproj
@@ -22,7 +22,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		56180D61E037A9C05A66B927 /* Pods_QuickStartOne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81B6CAEF177B653B31C0D0EB /* Pods_QuickStartOne.framework */; };
+		334A7322B1E4C74C05E2AE68 /* Pods_QuickStartsOne.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0170B353381D37D169C77EAD /* Pods_QuickStartsOne.framework */; };
+		56B39F942167C3EE00D4C74E /* Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 99D373D81F54D48E0079AA61 /* Info.plist */; };
 		994C87511FDB3027009C3BCE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 994C87501FDB3027009C3BCE /* AppDelegate.swift */; };
 		994C87561FDB3027009C3BCE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 994C87541FDB3027009C3BCE /* Main.storyboard */; };
 		994C87581FDB3027009C3BCE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 994C87571FDB3027009C3BCE /* Assets.xcassets */; };
@@ -35,7 +36,7 @@
 		99D373D41F54D48E0079AA61 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 99D373D31F54D48E0079AA61 /* Assets.xcassets */; };
 		99D373D71F54D48E0079AA61 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 99D373D51F54D48E0079AA61 /* LaunchScreen.storyboard */; };
 		99EBF5851F54F7D6001A03F2 /* ChatController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99EBF5841F54F7D5001A03F2 /* ChatController.swift */; };
-		A0E2AC3C957A77E5E699973C /* Pods_QuickStartTwo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDC36E4F063EA4042ADA891B /* Pods_QuickStartTwo.framework */; };
+		C964AAB396529B5941BC135B /* Pods_QuickStartTwo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 28A503CA26648A4C69618D16 /* Pods_QuickStartTwo.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -56,11 +57,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		14DFD9E4AABDCED0139C7834 /* Pods-QuickStartOne.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartOne.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartOne/Pods-QuickStartOne.debug.xcconfig"; sourceTree = "<group>"; };
-		247AB04A9584F6FAFB209BA1 /* Pods-QuickStartOne.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartOne.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartOne/Pods-QuickStartOne.release.xcconfig"; sourceTree = "<group>"; };
-		4BAD5209EB8DB9A21D9CEE50 /* Pods-QuickStartTwo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartTwo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo.debug.xcconfig"; sourceTree = "<group>"; };
-		81B6CAEF177B653B31C0D0EB /* Pods_QuickStartOne.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartOne.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		8599835F0D9AD1CDBBFC4A2E /* Pods-QuickStartTwo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartTwo.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo.release.xcconfig"; sourceTree = "<group>"; };
+		0170B353381D37D169C77EAD /* Pods_QuickStartsOne.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartsOne.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		28A503CA26648A4C69618D16 /* Pods_QuickStartTwo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartTwo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5C899E31D2F8BDBC1CC9D242 /* Pods-QuickStartTwo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartTwo.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo.debug.xcconfig"; sourceTree = "<group>"; };
+		7B2CB40902A0CEBC0AF47963 /* Pods-QuickStartTwo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartTwo.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo.release.xcconfig"; sourceTree = "<group>"; };
+		7B9C7A55E9D6447ECFCD0E49 /* Pods-QuickStartsOne.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartsOne.debug.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartsOne/Pods-QuickStartsOne.debug.xcconfig"; sourceTree = "<group>"; };
 		994C874E1FDB3027009C3BCE /* QuickStartTwo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuickStartTwo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		994C87501FDB3027009C3BCE /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		994C87551FDB3027009C3BCE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -77,7 +78,7 @@
 		99D373D61F54D48E0079AA61 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		99D373D81F54D48E0079AA61 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		99EBF5841F54F7D5001A03F2 /* ChatController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChatController.swift; sourceTree = "<group>"; };
-		DDC36E4F063EA4042ADA891B /* Pods_QuickStartTwo.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_QuickStartTwo.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9D2C453D5F86A2BD9E8D625 /* Pods-QuickStartsOne.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-QuickStartsOne.release.xcconfig"; path = "Pods/Target Support Files/Pods-QuickStartsOne/Pods-QuickStartsOne.release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,7 +86,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				A0E2AC3C957A77E5E699973C /* Pods_QuickStartTwo.framework in Frameworks */,
+				C964AAB396529B5941BC135B /* Pods_QuickStartTwo.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -93,7 +94,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				56180D61E037A9C05A66B927 /* Pods_QuickStartOne.framework in Frameworks */,
+				334A7322B1E4C74C05E2AE68 /* Pods_QuickStartsOne.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,11 +123,22 @@
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		12AF1115F2AE5DEB6B94D48C /* Frameworks */ = {
+		2EA1A81138C329BBCD47FE62 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				81B6CAEF177B653B31C0D0EB /* Pods_QuickStartOne.framework */,
-				DDC36E4F063EA4042ADA891B /* Pods_QuickStartTwo.framework */,
+				5C899E31D2F8BDBC1CC9D242 /* Pods-QuickStartTwo.debug.xcconfig */,
+				7B2CB40902A0CEBC0AF47963 /* Pods-QuickStartTwo.release.xcconfig */,
+				7B9C7A55E9D6447ECFCD0E49 /* Pods-QuickStartsOne.debug.xcconfig */,
+				F9D2C453D5F86A2BD9E8D625 /* Pods-QuickStartsOne.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
+		6A98EE63FB33B259E7B9DF34 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				28A503CA26648A4C69618D16 /* Pods_QuickStartTwo.framework */,
+				0170B353381D37D169C77EAD /* Pods_QuickStartsOne.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -148,8 +160,8 @@
 				99D373CB1F54D48E0079AA61 /* QuickStartOne */,
 				994C874F1FDB3027009C3BCE /* QuickStartTwo */,
 				99D373CA1F54D48E0079AA61 /* Products */,
-				C650B1F45E951092F1C58E02 /* Pods */,
-				12AF1115F2AE5DEB6B94D48C /* Frameworks */,
+				2EA1A81138C329BBCD47FE62 /* Pods */,
+				6A98EE63FB33B259E7B9DF34 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -173,17 +185,6 @@
 			path = QuickStartOne;
 			sourceTree = "<group>";
 		};
-		C650B1F45E951092F1C58E02 /* Pods */ = {
-			isa = PBXGroup;
-			children = (
-				14DFD9E4AABDCED0139C7834 /* Pods-QuickStartOne.debug.xcconfig */,
-				247AB04A9584F6FAFB209BA1 /* Pods-QuickStartOne.release.xcconfig */,
-				4BAD5209EB8DB9A21D9CEE50 /* Pods-QuickStartTwo.debug.xcconfig */,
-				8599835F0D9AD1CDBBFC4A2E /* Pods-QuickStartTwo.release.xcconfig */,
-			);
-			name = Pods;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -191,12 +192,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 994C875F1FDB3027009C3BCE /* Build configuration list for PBXNativeTarget "QuickStartTwo" */;
 			buildPhases = (
-				6A2E58ADA5C69101DB5E23E5 /* [CP] Check Pods Manifest.lock */,
+				2013D0D1D711B46D94BB38A4 /* [CP] Check Pods Manifest.lock */,
 				994C874A1FDB3027009C3BCE /* Sources */,
 				994C874B1FDB3027009C3BCE /* Frameworks */,
 				994C874C1FDB3027009C3BCE /* Resources */,
-				E25B1B11953E6BB5090699BC /* [CP] Embed Pods Frameworks */,
-				6C423B4FD24B9CD797E1370C /* [CP] Copy Pods Resources */,
+				B1E4389CC5994241C3A55AC7 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -211,12 +211,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 99D373DB1F54D48E0079AA61 /* Build configuration list for PBXNativeTarget "QuickStartsOne" */;
 			buildPhases = (
-				3AC2768C31166BB3EC76D341 /* [CP] Check Pods Manifest.lock */,
+				39F1C65205FC2C595AB50742 /* [CP] Check Pods Manifest.lock */,
 				99D373C51F54D48E0079AA61 /* Sources */,
 				99D373C61F54D48E0079AA61 /* Frameworks */,
 				99D373C71F54D48E0079AA61 /* Resources */,
-				91994C22A2B9710B86E9C0C0 /* [CP] Embed Pods Frameworks */,
-				414D774F906D00F148F3A471 /* [CP] Copy Pods Resources */,
+				C04DD81496E84DAF822C09EA /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -286,6 +285,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				56B39F942167C3EE00D4C74E /* Info.plist in Resources */,
 				99D373D71F54D48E0079AA61 /* LaunchScreen.storyboard in Resources */,
 				99D373D41F54D48E0079AA61 /* Assets.xcassets in Resources */,
 				99D373D21F54D48E0079AA61 /* Main.storyboard in Resources */,
@@ -295,40 +295,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		3AC2768C31166BB3EC76D341 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-QuickStartOne-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		414D774F906D00F148F3A471 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartOne/Pods-QuickStartOne-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		6A2E58ADA5C69101DB5E23E5 /* [CP] Check Pods Manifest.lock */ = {
+		2013D0D1D711B46D94BB38A4 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -346,56 +313,25 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		6C423B4FD24B9CD797E1370C /* [CP] Copy Pods Resources */ = {
+		39F1C65205FC2C595AB50742 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
-			name = "[CP] Copy Pods Resources";
+			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-QuickStartsOne-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		91994C22A2B9710B86E9C0C0 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartOne/Pods-QuickStartOne-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
-				"${BUILT_PRODUCTS_DIR}/NexmoGRDB.swift/GRDB.framework",
-				"${PODS_ROOT}/NexmoWebRTC/WebRTC.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
-				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
-				"${BUILT_PRODUCTS_DIR}/Socket.IO-Client-Swift/SocketIO.framework",
-				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework.dSYM",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GRDB.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SocketIO.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NexmoConversation.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/NexmoConversation.framework.dSYM",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartOne/Pods-QuickStartOne-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		E25B1B11953E6BB5090699BC /* [CP] Embed Pods Frameworks */ = {
+		B1E4389CC5994241C3A55AC7 /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -403,30 +339,60 @@
 			inputPaths = (
 				"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework.dSYM",
 				"${BUILT_PRODUCTS_DIR}/NexmoGRDB.swift/GRDB.framework",
 				"${PODS_ROOT}/NexmoWebRTC/WebRTC.framework",
-				"${BUILT_PRODUCTS_DIR}/RxCocoa/RxCocoa.framework",
 				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
 				"${BUILT_PRODUCTS_DIR}/Socket.IO-Client-Swift/SocketIO.framework",
 				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework",
-				"${PODS_ROOT}/Stitch/Carthage/Build/iOS/NexmoConversation.framework.dSYM",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Stitch.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Stitch.framework.dSYM",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GRDB.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxCocoa.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SocketIO.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/NexmoConversation.framework",
-				"${DWARF_DSYM_FOLDER_PATH}/NexmoConversation.framework.dSYM",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartTwo/Pods-QuickStartTwo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		C04DD81496E84DAF822C09EA /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartsOne/Pods-QuickStartsOne-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Alamofire/Alamofire.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework",
+				"${PODS_ROOT}/Nexmo-Stitch/Carthage/Build/iOS/Stitch.framework.dSYM",
+				"${BUILT_PRODUCTS_DIR}/NexmoGRDB.swift/GRDB.framework",
+				"${PODS_ROOT}/NexmoWebRTC/WebRTC.framework",
+				"${BUILT_PRODUCTS_DIR}/RxSwift/RxSwift.framework",
+				"${BUILT_PRODUCTS_DIR}/Socket.IO-Client-Swift/SocketIO.framework",
+				"${BUILT_PRODUCTS_DIR}/Starscream/Starscream.framework",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Alamofire.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Stitch.framework",
+				"${DWARF_DSYM_FOLDER_PATH}/Stitch.framework.dSYM",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/GRDB.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/WebRTC.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/RxSwift.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SocketIO.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Starscream.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-QuickStartsOne/Pods-QuickStartsOne-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -521,7 +487,7 @@
 		};
 		994C875D1FDB3027009C3BCE /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4BAD5209EB8DB9A21D9CEE50 /* Pods-QuickStartTwo.debug.xcconfig */;
+			baseConfigurationReference = 5C899E31D2F8BDBC1CC9D242 /* Pods-QuickStartTwo.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -547,7 +513,7 @@
 		};
 		994C875E1FDB3027009C3BCE /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8599835F0D9AD1CDBBFC4A2E /* Pods-QuickStartTwo.release.xcconfig */;
+			baseConfigurationReference = 7B2CB40902A0CEBC0AF47963 /* Pods-QuickStartTwo.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
@@ -678,12 +644,12 @@
 		};
 		99D373DC1F54D48E0079AA61 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 14DFD9E4AABDCED0139C7834 /* Pods-QuickStartOne.debug.xcconfig */;
+			baseConfigurationReference = 7B9C7A55E9D6447ECFCD0E49 /* Pods-QuickStartsOne.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "QuickStartOne/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.unicornmobile.QuickStartOne;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nexmo.QuickStartOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};
@@ -691,12 +657,12 @@
 		};
 		99D373DD1F54D48E0079AA61 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 247AB04A9584F6FAFB209BA1 /* Pods-QuickStartOne.release.xcconfig */;
+			baseConfigurationReference = F9D2C453D5F86A2BD9E8D625 /* Pods-QuickStartsOne.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = "QuickStartOne/Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				PRODUCT_BUNDLE_IDENTIFIER = io.unicornmobile.QuickStartOne;
+				PRODUCT_BUNDLE_IDENTIFIER = com.nexmo.QuickStartOne;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};

--- a/examples/QuickStarts.xcworkspace/contents.xcworkspacedata
+++ b/examples/QuickStarts.xcworkspace/contents.xcworkspacedata
@@ -2,7 +2,7 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:/Users/shamsahmed/Project/conversation-ios-quickstart/examples/QuickStarts.xcodeproj">
+      location = "group:QuickStarts.xcodeproj">
    </FileRef>
    <FileRef
       location = "group:Pods/Pods.xcodeproj">

--- a/examples/convenience-calling/Podfile.lock
+++ b/examples/convenience-calling/Podfile.lock
@@ -16,6 +16,16 @@ PODS:
 DEPENDENCIES:
   - Nexmo-Stitch
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Nexmo-Stitch
+    - NexmoGRDB.swift
+    - NexmoWebRTC
+    - RxSwift
+    - Socket.IO-Client-Swift
+    - Starscream
+
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
   Nexmo-Stitch: afa2dc2d33c48e4792ff9c4d4ca146b28657cc4d
@@ -27,4 +37,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 84e5211092693d25a0823331ff33380c383cbf9e
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2

--- a/examples/convenience-calling/convenience-calling.xcodeproj/project.pbxproj
+++ b/examples/convenience-calling/convenience-calling.xcodeproj/project.pbxproj
@@ -103,7 +103,6 @@
 				9975DE5920B8A68600AE3613 /* Frameworks */,
 				9975DE5A20B8A68600AE3613 /* Resources */,
 				E20D34D81398755529DCF5C2 /* [CP] Embed Pods Frameworks */,
-				4DE55A15E8F92F1362870CCB /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -178,21 +177,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		4DE55A15E8F92F1362870CCB /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-convenience-calling/Pods-convenience-calling-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		E20D34D81398755529DCF5C2 /* [CP] Embed Pods Frameworks */ = {

--- a/examples/convenience-calling/convenience-calling/Base.lproj/Main.storyboard
+++ b/examples/convenience-calling/convenience-calling/Base.lproj/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="duS-im-I6J">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="duS-im-I6J">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13527"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -18,8 +18,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lcv-b2-iQA">
-                                <rect key="frame" x="166" y="323" width="42" height="21"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Status" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lcv-b2-iQA">
+                                <rect key="frame" x="166" y="323" width="50" height="21"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
@@ -29,13 +29,17 @@
                                 <rect key="frame" x="16" y="617" width="46" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Login"/>
+                                <connections>
+                                    <action selector="loginBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="QpA-Iy-EIX"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v6m-w1-war">
                                 <rect key="frame" x="313" y="617" width="46" height="30"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Chat"/>
                                 <connections>
-                                    <segue destination="KtU-Cp-ncF" kind="show" id="DmC-XZ-CYg"/>
+                                    <action selector="chatBtn:" destination="BYZ-38-t0r" eventType="touchUpInside" id="nYa-6d-NuV"/>
+                                    <segue destination="KtU-Cp-ncF" kind="show" identifier="chatView" id="DmC-XZ-CYg"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -43,6 +47,9 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                     <navigationItem key="navigationItem" id="7Cx-Ku-clz"/>
+                    <connections>
+                        <outlet property="statusLbl" destination="lcv-b2-iQA" id="pgN-y3-GE7"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>

--- a/examples/convenience-calling/convenience-calling/ChatController.swift
+++ b/examples/convenience-calling/convenience-calling/ChatController.swift
@@ -32,7 +32,7 @@ class ChatController: UIViewController {
         
         do {
             // send method
-            try consversation?.send(textField.text!)
+            try conversation?.send(textField.text!)
             
         } catch let error {
             print(error)
@@ -42,36 +42,37 @@ class ChatController: UIViewController {
 
     // MARK: - viewDidLoad()
     override func viewDidLoad() {
-        super.viewDidload()
+        super.viewDidLoad()
         
-        tableView.delegate = self
+        tableView.delegate = self as? UITableViewDelegate
         tableView.dataSource = self
         
         // a handler for updating the textView with TextEvents
-        conversation?.events.newEventReceived.addHandler { event in
-            
+        conversation?.events.newEventReceived.subscribe(onSuccess: { (event) in
             guard let event = event as? TextEvent, event.isCurrentlyBeingSent == false else { return }
             
             guard let text = event.text else { return }
             
-            self.textView.insertText(" \(text) \n ")
-        }
+            self.textField.insertText(" \(text) \n ")
+
+        }, onError: { (error) in
+            
+        })
         
     }
 
     // MARK: - Call Convenience Methods
     private func call() {
         
-        let callAlert = UIAlertController(title: "Call", message: "Who would you like to call?", preferredStyle: .sheet)
+        let callAlert = UIAlertController(title: "Call", message: "Who would you like to call?", preferredStyle: .actionSheet)
         
         conversation?.members.forEach{ member in
-            callAlert.addAction(UIAlertAction(title: member.user.username, style: .default, handler: {
-                
-                    ConversationClient.instance.media.call(member.user.username, onSuccess: { result in
-                        // if you would like to display a UI for calling...
-                    }, onError: { networkError in
-                        // if you would like to display a log for error...
-                    })
+            callAlert.addAction(UIAlertAction(title: member.user.name, style: .default, handler: { (action) in
+                ConversationClient.instance.media.call([member.user.name], onSuccess: { result in
+                    // if you would like to display a UI for calling...
+                }, onError: { networkError in
+                    // if you would like to display a log for error...
+                })
             }))
         }
         

--- a/examples/convenience-calling/convenience-calling/LoginViewController.swift
+++ b/examples/convenience-calling/convenience-calling/LoginViewController.swift
@@ -99,7 +99,7 @@ class LoginViewController: UIViewController {
         })
         
         DispatchQueue.main.async {
-        performSegue(withIdentifier: "chatView", sender: nil)
+        self.performSegue(withIdentifier: "chatView", sender: nil)
         }
     }
     

--- a/examples/simple-conversation/simple-conversation-objc/Podfile
+++ b/examples/simple-conversation/simple-conversation-objc/Podfile
@@ -2,8 +2,7 @@ platform :ios, '10.0'
 
 use_frameworks!
 
-source "https://github.com/Nexmo/PodSpec.git"
-
+source 'git@github.com:CocoaPods/Specs.git'
 
 target 'simple-conversation-objc' do
 

--- a/examples/simple-conversation/simple-conversation-objc/Podfile
+++ b/examples/simple-conversation/simple-conversation-objc/Podfile
@@ -3,11 +3,10 @@ platform :ios, '10.0'
 use_frameworks!
 
 source "https://github.com/Nexmo/PodSpec.git"
-source 'git@github.com:CocoaPods/Specs.git'
 
 
 target 'simple-conversation-objc' do
 
-  pod "Nexmo-Stitch" #, :git => "https://github.com/nexmo/conversation-ios-sdk.git", :branch => "release" # $
+  pod "Nexmo-Stitch"
 
 end

--- a/examples/simple-conversation/simple-conversation-objc/Podfile.lock
+++ b/examples/simple-conversation/simple-conversation-objc/Podfile.lock
@@ -16,15 +16,25 @@ PODS:
 DEPENDENCIES:
   - Nexmo-Stitch
 
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - Nexmo-Stitch
+    - NexmoGRDB.swift
+    - NexmoWebRTC
+    - RxSwift
+    - Socket.IO-Client-Swift
+    - Starscream
+
 SPEC CHECKSUMS:
   Alamofire: e4fa87002c137ba2d8d634d2c51fabcda0d5c223
   Nexmo-Stitch: afa2dc2d33c48e4792ff9c4d4ca146b28657cc4d
   NexmoGRDB.swift: a3f76f83f87c0836f3b2cdb375aa7e9e9f8bce3a
-  NexmoWebRTC: efb9a506e6107d12399114b621f4b71b07c56d75
+  NexmoWebRTC: 259075ae09616c4b847024f0dccd22650dc3a14c
   RxSwift: 99e10317ddfcc7fbe01356aafd118fde4a0be104
   Socket.IO-Client-Swift: b94943e2fb916fe2f95244b9ed21828634002280
   Starscream: faf918b2f2eff7d5dd21180646bf015a669673bd
 
-PODFILE CHECKSUM: 2e2f50dfab7a27f8a3f8a1f24408e580c8f3da08
+PODFILE CHECKSUM: be67c0eaf4667d47b27a3494c2d87326ba4fae9e
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.2

--- a/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc.xcodeproj/project.pbxproj
+++ b/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		29F8DC409738E0D99016DF52 /* Pods_simple_conversation_objc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0954C98868F431FFB72F1367 /* Pods_simple_conversation_objc.framework */; };
+		563F68902167D0E400EB166C /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 563F688F2167D0E400EB166C /* ViewController.m */; };
 		993CF1DE20D1C0FA00E55BFD /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 993CF1DD20D1C0FA00E55BFD /* AppDelegate.m */; };
 		993CF1E420D1C0FA00E55BFD /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 993CF1E220D1C0FA00E55BFD /* Main.storyboard */; };
 		993CF1E620D1C0FA00E55BFD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 993CF1E520D1C0FA00E55BFD /* Assets.xcassets */; };
@@ -14,12 +16,13 @@
 		993CF1EC20D1C0FA00E55BFD /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 993CF1EB20D1C0FA00E55BFD /* main.m */; };
 		99F0957920D1C6A100F10D5B /* ChatVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 99F0957820D1C6A100F10D5B /* ChatVC.m */; };
 		99F0957C20D1C6B000F10D5B /* LoginVC.m in Sources */ = {isa = PBXBuildFile; fileRef = 99F0957B20D1C6B000F10D5B /* LoginVC.m */; };
-		C11F848C5DD5A6DDB5ED09DC /* Pods_simple_conversation_objc.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 110A93AA2004A9756C39D1F8 /* Pods_simple_conversation_objc.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		10DA3FCF0C22952BA3CB1024 /* Pods-simple-conversation-objc.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-simple-conversation-objc.release.xcconfig"; path = "Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc.release.xcconfig"; sourceTree = "<group>"; };
-		110A93AA2004A9756C39D1F8 /* Pods_simple_conversation_objc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_simple_conversation_objc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0954C98868F431FFB72F1367 /* Pods_simple_conversation_objc.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_simple_conversation_objc.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		563F688E2167D0E400EB166C /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		563F688F2167D0E400EB166C /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		7A23D9B1045FF65E353B9727 /* Pods-simple-conversation-objc.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-simple-conversation-objc.release.xcconfig"; path = "Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc.release.xcconfig"; sourceTree = "<group>"; };
 		993CF1D920D1C0FA00E55BFD /* simple-conversation-objc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "simple-conversation-objc.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		993CF1DC20D1C0FA00E55BFD /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		993CF1DD20D1C0FA00E55BFD /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -32,7 +35,7 @@
 		99F0957820D1C6A100F10D5B /* ChatVC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ChatVC.m; sourceTree = "<group>"; };
 		99F0957A20D1C6B000F10D5B /* LoginVC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LoginVC.h; sourceTree = "<group>"; };
 		99F0957B20D1C6B000F10D5B /* LoginVC.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LoginVC.m; sourceTree = "<group>"; };
-		E9CEA808FFBF631722BFC303 /* Pods-simple-conversation-objc.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-simple-conversation-objc.debug.xcconfig"; path = "Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc.debug.xcconfig"; sourceTree = "<group>"; };
+		AF6F101A920AD3D4EA6DBC56 /* Pods-simple-conversation-objc.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-simple-conversation-objc.debug.xcconfig"; path = "Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -40,28 +43,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C11F848C5DD5A6DDB5ED09DC /* Pods_simple_conversation_objc.framework in Frameworks */,
+				29F8DC409738E0D99016DF52 /* Pods_simple_conversation_objc.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		7A4FBF24DE956FEA3973803C /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				110A93AA2004A9756C39D1F8 /* Pods_simple_conversation_objc.framework */,
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
 		993CF1D020D1C0FA00E55BFD = {
 			isa = PBXGroup;
 			children = (
 				993CF1DB20D1C0FA00E55BFD /* simple-conversation-objc */,
 				993CF1DA20D1C0FA00E55BFD /* Products */,
-				E1446AA6AAC853650B4D6591 /* Pods */,
-				7A4FBF24DE956FEA3973803C /* Frameworks */,
+				AFE12661B9E36AFB7095CC7B /* Pods */,
+				B0909570B66CB6DE66AA99DE /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -87,17 +82,27 @@
 				993CF1E720D1C0FA00E55BFD /* LaunchScreen.storyboard */,
 				993CF1EA20D1C0FA00E55BFD /* Info.plist */,
 				993CF1EB20D1C0FA00E55BFD /* main.m */,
+				563F688E2167D0E400EB166C /* ViewController.h */,
+				563F688F2167D0E400EB166C /* ViewController.m */,
 			);
 			path = "simple-conversation-objc";
 			sourceTree = "<group>";
 		};
-		E1446AA6AAC853650B4D6591 /* Pods */ = {
+		AFE12661B9E36AFB7095CC7B /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				E9CEA808FFBF631722BFC303 /* Pods-simple-conversation-objc.debug.xcconfig */,
-				10DA3FCF0C22952BA3CB1024 /* Pods-simple-conversation-objc.release.xcconfig */,
+				AF6F101A920AD3D4EA6DBC56 /* Pods-simple-conversation-objc.debug.xcconfig */,
+				7A23D9B1045FF65E353B9727 /* Pods-simple-conversation-objc.release.xcconfig */,
 			);
 			name = Pods;
+			sourceTree = "<group>";
+		};
+		B0909570B66CB6DE66AA99DE /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				0954C98868F431FFB72F1367 /* Pods_simple_conversation_objc.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -107,12 +112,11 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 993CF1EF20D1C0FA00E55BFD /* Build configuration list for PBXNativeTarget "simple-conversation-objc" */;
 			buildPhases = (
-				F3EC6A705E59A303F443D10D /* [CP] Check Pods Manifest.lock */,
+				C1FE78339CFF797D47FFC72B /* [CP] Check Pods Manifest.lock */,
 				993CF1D520D1C0FA00E55BFD /* Sources */,
 				993CF1D620D1C0FA00E55BFD /* Frameworks */,
 				993CF1D720D1C0FA00E55BFD /* Resources */,
-				05930C0F8B71F08D82FC8689 /* [CP] Embed Pods Frameworks */,
-				BD532CB705F116B83E168C4A /* [CP] Copy Pods Resources */,
+				53879339EA619CC7530C5FDC /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -170,7 +174,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		05930C0F8B71F08D82FC8689 /* [CP] Embed Pods Frameworks */ = {
+		53879339EA619CC7530C5FDC /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -202,22 +206,7 @@
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		BD532CB705F116B83E168C4A /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-simple-conversation-objc/Pods-simple-conversation-objc-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		F3EC6A705E59A303F443D10D /* [CP] Check Pods Manifest.lock */ = {
+		C1FE78339CFF797D47FFC72B /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -246,6 +235,7 @@
 				993CF1EC20D1C0FA00E55BFD /* main.m in Sources */,
 				99F0957C20D1C6B000F10D5B /* LoginVC.m in Sources */,
 				993CF1DE20D1C0FA00E55BFD /* AppDelegate.m in Sources */,
+				563F68902167D0E400EB166C /* ViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,7 +367,7 @@
 		};
 		993CF1F020D1C0FA00E55BFD /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E9CEA808FFBF631722BFC303 /* Pods-simple-conversation-objc.debug.xcconfig */;
+			baseConfigurationReference = AF6F101A920AD3D4EA6DBC56 /* Pods-simple-conversation-objc.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -391,7 +381,7 @@
 		};
 		993CF1F120D1C0FA00E55BFD /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 10DA3FCF0C22952BA3CB1024 /* Pods-simple-conversation-objc.release.xcconfig */;
+			baseConfigurationReference = 7A23D9B1045FF65E353B9727 /* Pods-simple-conversation-objc.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/Base.lproj/Main.storyboard
+++ b/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/Base.lproj/Main.storyboard
@@ -1,7 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -9,7 +13,7 @@
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/ViewController.h
+++ b/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/ViewController.h
@@ -1,0 +1,13 @@
+//
+//  ViewController.h
+//  simple-conversation-objc
+//
+//  Created by Tony Hung on 10/5/18.
+//  Copyright © 2018 Nexmo, Inc. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface ViewController : UIViewController
+
+@end

--- a/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/ViewController.m
+++ b/examples/simple-conversation/simple-conversation-objc/simple-conversation-objc/ViewController.m
@@ -1,0 +1,37 @@
+//
+//  ViewController.m
+//  simple-conversation-objc
+//
+//  Created by Tony Hung on 10/5/18.
+//  Copyright © 2018 Nexmo, Inc. All rights reserved.
+//
+
+#import "ViewController.h"
+
+@interface ViewController ()
+
+@end
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    // Do any additional setup after loading the view.
+}
+
+- (void)didReceiveMemoryWarning {
+    [super didReceiveMemoryWarning];
+    // Dispose of any resources that can be recreated.
+}
+
+/*
+#pragma mark - Navigation
+
+// In a storyboard-based application, you will often want to do a little preparation before navigation
+- (void)prepareForSegue:(UIStoryboardSegue *)segue sender:(id)sender {
+    // Get the new view controller using [segue destinationViewController].
+    // Pass the selected object to the new view controller.
+}
+*/
+
+@end


### PR DESCRIPTION
Updating the examples to use the latest pod, named `Nexmo-Stitch`
Examples that used older pod name(`NexmoConversation`) do not support Swift 4.1

